### PR TITLE
Clean up I/O board docs and spec notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OOMWOO I/O Board (STM32G070 based)
 
 
-**Current plan - the I/O board will (likely) accept CM4/CM5 Raspberry Pi compute module (and other compatible 3rd party compute modules).**
+**Current plan: the I/O board will likely accept a CM4/CM5 Raspberry Pi Compute Module (and other compatible third-party compute modules).**
 
 
 Schematic (PDF) for the [OOMWOO](https://github.com/makerspet/oomwoo) open-source robot
@@ -19,7 +19,7 @@ Consumer vacuums typically split compute into CPU and MCU. The MCU ([real exampl
 - all sensors except below - IR cliff, IR side proximity, IR docking, wheel drop, bumper (IR or micro-switches), motor encoders, ultrasonic carpet sensor
 - all push buttons
 - 2D LiDAR motor RPM
-- power - battery charging, motors power on/of
+- power - battery charging, motors power on/off
 - all safety sensors - overcurrent for all motors (cheap vacuums ignore overcurrent sensing)
 
 I/O board also provides audio encoders/decoders, amp, speaker (connector), mics (if any).
@@ -29,11 +29,11 @@ CPU receives
 - IMU (sometimes IMU gets forwarded via MCU) over SPI/I2C
 - cameras (2x MIPI for visual obstacle avoidance)
 
-MCU (and CPU)) are usually always active. This allows the user to start cleaning at any time (especially via app remotely). Exceptions:
+MCU (and CPU) are usually always active. This allows the user to start cleaning at any time (especially via app remotely). Exceptions:
 - no power (battery dead and no dock power)
 - user explicitly shut down the vacuum by long-pressing the power button
 
-MCU overarching constrait is to ensure robot safety. This is necesary to pass CE mark tests. Here is how MCU ensures safety:
+The MCU's overarching constraint is to ensure robot safety. This is necessary to pass CE mark tests. Here is how MCU ensures safety:
 - MCU firmware uses FreeRTOS or similar, static memory allocation, watchdog, guaranteed reaction time
 - MCU acts as watchdog for CPU, resets CPU if CPU becomes unresponsive
 - MCU connects to CPU over serial using a custom serial protocol ([concrete example](https://github.com/codetiger/VacuumRobot)). No micro-ROS to reduce dependencies, prevent bugs from updated 3rd party libraries slipping into safety-critical MCU firmware.
@@ -48,7 +48,7 @@ MCU overarching constrait is to ensure robot safety. This is necesary to pass CE
 Consumer vacuums place CPU and MCU on the same PCB board. Since OOMWOO has to be hackable, it seems best to separate I/O from the compute. Therefore, this I/O board needs to have
 - MCU and programming header
   - likely STM32G070RBT6 because it has 56 GPIOs, 16 ADC channels, costs $1 at JLCPCB, has LQFP package for easy PCBA - a rare combination
-  - see tentative [GPIO budget](https://github.com/makerspet/oomwoo-io-board/blob/main/docs/GPIO.md)
+  - see tentative [I/O board spec](https://github.com/makerspet/oomwoo-io-board/blob/main/docs/SPEC.md)
 - all vacuum motor drivers (with connectors), driven by the MCU
   - cliff, side proximity, docking, bumper, carpet, water tank full/empty, dust bin present, motor overcurrent, motor encoders
 - MCU connected to all sensors (except those handled by CPU like LiDAR serial, MIPI cameras I/O, IMU); sensor connectors
@@ -65,7 +65,7 @@ Consumer vacuums usually don't have a CPU fan/heatsink because the vacuum's suct
 
 As far as compute - currently it seems best to use a Raspberry Pi CM4/CM5 compute module. Why?
 - CM4/CM5 modules cost a bit less than a full Raspberry Pi 4/5
-- CN4/CM5 have lower profile/height vs a full Raspberry Pi 4/5, important to keep vacuum cleaner slim
+- CM4/CM5 have lower profile/height vs a full Raspberry Pi 4/5, important to keep vacuum cleaner slim
 - there are plenty of 3rd party compute modules pin-compatible with CM4/CM5, making the compute swappable, hackable
   - 3rd party compute modules with NPUs are especially interesting because we need NPU for real-time camera-based obstacle detection
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -25,13 +25,13 @@ View [BRR-2P4S-5200FL battery datasheet](https://images.thdstatic.com/catalog/pd
 - USB-C PD, request 20 V minimum (to step it down to 4S battery)
 - optional PPS
 - 65W minimum with system power-path charger (a charger IC with a SYS rail)
-  - support the vacuum charing and Raspberry Pi running simultaneously
+  - support the vacuum charging and Raspberry Pi running simultaneously
   - assume Raspberry Pi is always on (to handle user access over Wi-Fi at any time)
   - Pi 5 worst case ~25 W (5 V/5 A) + housekeeping ≈ up to ~25–30 W
   - Healthy charge ~40 W (~0.5C into the 75 Wh pack)
   - ~65–70 W total
 - cap charge at ~0.5C regardless of charging adapter power
-- the two dock contacts are the
+- TODO: clarify whether the two dock contacts are power-only, or whether dock presence needs a separate sense signal.
 - if only a 5V, 9V or 15V source is attached (no 20V/PPS), either charge slowly (optional) through a boost path or cleanly refuse and signal "insufficient charger" rather than misbehaving
 - assume dock contacts feeding a fixed 20V+ DC; the dock will likely have its own PD sink, converting the dock's brick to 20V DC fixed.
 
@@ -125,3 +125,5 @@ Net spec
 58. Side proximity IR LED right PWM (digital out)
 59. Wheel drop sensor left (digital in)
 60. Wheel drop sensor right (digital in)
+
+TODO before layout/fabrication: confirm whether GPIO entries 36 and 46 are intentionally separate bumper inputs or a duplicate label.


### PR DESCRIPTION
Small documentation cleanup for the current I/O board draft: fixes README typos and the renamed SPEC link, replaces an incomplete dock-contact bullet with an explicit TODO, and notes the apparent duplicate bumper GPIO label for review. No hardware behavior is changed.